### PR TITLE
Change calculations to tensor operations

### DIFF
--- a/src/response.jl
+++ b/src/response.jl
@@ -2,77 +2,70 @@
 # License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
 using Tensors
 
-generate_elastic_tensor{P<:Elastic}(mat::P, dim) = generate_elastic_tensor(mat, dim, nothing)
-
-"""
-    generate_elastic_tensor_2D(E, nu, ::Type{Val{:plane_stress}})
-
-Calculate elastic moduli in plain stress formulation
-
-"""
-function generate_elastic_tensor_2D(E, nu, ::Type{Val{:plane_stress}})
-    D = E/(1.0 - nu^2) .* [
-            1.0   nu    0.0
-             nu  1.0    0.0
-            0.0  0.0 1.0-nu]
-    Tensor{2, 3}(D)
-end
-
-"""
-    generate_elastic_tensor_2D(E, nu, ::Type{Val{:plane_strain}})
-
-Calculate elastic moduli in plane stress formulation
-"""
-function generate_elastic_tensor_2D(E, nu, ::Type{Val{:plane_strain}})
-    D = E/((1.0+nu)*(1.0-2.0*nu)) .* [
-            1.0-nu      nu         0.0
-                nu  1.0-nu         0.0
-                0.0     0.0 1.0-2.0*nu]
-    Tensor{2, 3}(D)
-end
+kron_delta = (i, j) -> i == j ? 1 : 0
+ident_func = (i,j,k,l) -> 1/2 * (kron_delta(i,k)*kron_delta(j,l) + kron_delta(i,l)*kron_delta(j,k))
 
 """
     generate_elastic_tensor_3D(E, nu)
 
 Calculate 4th order elastic moduli
-ref: https://en.wikipedia.org/wiki/Lam%C3%A9_parameters
+ref: https://en.wikipedia.org/wiki/Hooke's_law
 """
-function generate_elastic_tensor_3D(E, nu)
-    
-    # Lame constants
-    kron_delta = (i, j) -> i == j ? 1 : 0
-    
+function generate_elastic_tensor(E, nu)
     # Lame constants
     lambda = (E * nu) / ((1 + nu) * (1 - 2*nu))
     my = E / (2*(1 + nu))
 
     # Identity tensor
     ident_tensor = one(Tensor{2, 3})
-    f = (i,j,k,l) -> 1/2 * (kron_delta(i,k)*kron_delta(j,l) + kron_delta(i,l)*kron_delta(j,k))
-    II = Tensor{4, 3, Float64}(f)
+    II = Tensor{4, 3, Float64}(ident_func)
 
     # Elastic moduli
     lambda * otimes(ident_tensor, ident_tensor) + 2*my*II
 end
 
 """
-    generate_elastic_tensor{P<:Elastic}(mat::P, dim, formulation)
+    generate_elastic_tensor_plane_stress(E, nu) 
 
-Calculate elastic moduli
+Calculate 4th order elastic moduli for plane stress
+formulation
 """
-function generate_elastic_tensor{P<:Elastic}(mat::P, dim, formulation)
-    E = mat.youngs_modulus
-    nu = mat.nu
-    if dim == 1
-        return E
-    elseif dim == 2
-        return generate_elastic_tensor_2D(E, nu, Val{formulation})
-    elseif dim == 3
-        return generate_elastic_tensor_3D(E, nu)
-    else
-        error("Did not understand dimension. Given dimension $dim.")
+function generate_elastic_tensor_plane_stress(E, nu)
+
+    """
+        Remove all the sigma_xz, sigma_yz and sigma_zz elements
+    """
+    function case(i, k)
+        (i == 3 && k == 1 ||
+         i == 3 && k == 2 ||
+         i == 1 && k == 3 ||
+         i == 2 && k == 3 ||
+         i == 3 && k == 3)
     end
+
+    # Lame constant
+    my = E / (2*(1 + nu))
+
+    # Compensation for plane stress
+    lambda = (E * nu) / (1 - nu^2)
+
+    # Identity tensor, but do not include sigma_zz element
+    it = eye(3,3)
+    it[3,3] = 0
+    ident_tensor = Tensor{2, 3}(it)
+
+    # Remove all sigma_xz, sigma_yz and sigma_zz elements
+    g = (i,j,k,l) -> case(k, l) ? 0.0 : ident_func(i,j,k,l)
+    II = Tensor{4, 3, Float64}(g)
+
+    # Elastic moduli
+    lambda * otimes(ident_tensor, ident_tensor) + 2*my*II
+
 end
+
+generate_elastic_tensor(mat::IsotropicHooke, ::Type{Val{:plane_stress}}) = generate_elastic_tensor_plane_stress(mat.youngs_modulus, mat.nu)
+generate_elastic_tensor(mat::IsotropicHooke, ::Type{Val{:plane_strain}}) = generate_elastic_tensor(mat.youngs_modulus, mat.nu)
+generate_elastic_tensor(mat::IsotropicHooke) = generate_elastic_tensor(mat.youngs_modulus, mat.nu)
 
 """
     generate_strain(gradu, dim, finite_strain::Bool)
@@ -85,7 +78,13 @@ function generate_strain(gradu, dim, finite_strain::Bool)
     else
         strain = 1/2*(gradu + gradu')
     end
-    Tensor{2, dim}(strain)
+    if dim == 2
+        strain_mat = zeros(3,3)
+        strain_mat[1:2, 1:2] = strain[:,:]
+    else
+        strain_mat = strain
+    end
+    Tensor{2, 3}(strain_mat)
 end
 
 """
@@ -103,48 +102,28 @@ function generate_deformation_gradient(gradu, dim, finite_strain::Bool)
 end
 
 """
-    calculate_2D(mat::Material, gradu)
-
-Calculate stress either in plane stress or plain strain formulation
-"""
-function calculate_2D(mat::Material, gradu)
-    formulation = mat.formulation
-    finite_strain = mat.finite_strain
-    elastic_properties = mat.properties["elastic"]    
-    D = generate_elastic_tensor(elastic_properties, 2, formulation)
-    F = generate_deformation_gradient(gradu, 2, finite_strain)
-    strain = generate_strain(gradu, 2, finite_strain)
-    strain_vec = Tensor{1, 3}([strain[1,1], strain[2,2], strain[1,2]])
-    dot(D, strain_vec)
-end
-
-"""
-    calculate_3D(mat::Material, gradu)
-
-Calculate stress either in plane stress or plain strain formulation
-"""
-function calculate_3D(mat::Material, gradu)
-    finite_strain = mat.finite_strain
-    elastic_properties = mat.properties["elastic"]
-    D = generate_elastic_tensor(elastic_properties, 3)
-    F = generate_deformation_gradient(gradu, 3, finite_strain)
-    strain = generate_strain(gradu, 3, finite_strain)
-    dcontract(D, strain)
-end
-
-"""
     calc_response(mat::Material, gradu)
 
 Calculate corresponding stress for a given strain
 """
 function calc_response(mat::Material, gradu)
     dim = mat.dimension
+    elastic = mat.properties["elastic"]
+    finite_strain = mat.finite_strain
+
     if dim == 1
         error("Not implemented yet")
+
     elseif dim == 2
-        stress = calculate_2D(mat, gradu)
+        D = generate_elastic_tensor(elastic, Val{mat.formulation})
+        strain = generate_strain(gradu, 2, finite_strain)
+        F = generate_deformation_gradient(gradu, 2, finite_strain)
+
     elseif dim == 3
-        stress = calculate_3D(mat, gradu)
+        D = generate_elastic_tensor(elastic)
+        strain = generate_strain(gradu, 3, finite_strain)
+        F = generate_deformation_gradient(gradu, 3, finite_strain)
+        
     end
-    stress
+    stress = dcontract(D, strain)
 end

--- a/src/response.jl
+++ b/src/response.jl
@@ -2,8 +2,8 @@
 # License is MIT: see https://github.com/JuliaFEM/JuliaFEM.jl/blob/master/LICENSE.md
 using Tensors
 
-kron_delta = (i, j) -> i == j ? 1 : 0
-ident_func = (i,j,k,l) -> 1/2 * (kron_delta(i,k)*kron_delta(j,l) + kron_delta(i,l)*kron_delta(j,k))
+kron_delta(i, j) = i == j ? 1 : 0
+ident_func(i,j,k,l) = 1/2 * (kron_delta(i,k)*kron_delta(j,l) + kron_delta(i,l)*kron_delta(j,k))
 
 """
     generate_elastic_tensor_3D(E, nu)
@@ -28,7 +28,8 @@ end
     generate_elastic_tensor_plane_stress(E, nu) 
 
 Calculate 4th order elastic moduli for plane stress
-formulation
+formulation. 
+ref: https://ocw.mit.edu/courses/mechanical-engineering/2-080j-structural-mechanics-fall-2013/course-notes/MIT2_080JF13_Lecture4.pdf
 """
 function generate_elastic_tensor_plane_stress(E, nu)
 
@@ -50,9 +51,8 @@ function generate_elastic_tensor_plane_stress(E, nu)
     lambda = (E * nu) / (1 - nu^2)
 
     # Identity tensor, but do not include sigma_zz element
-    it = eye(3,3)
-    it[3,3] = 0
-    ident_tensor = Tensor{2, 3}(it)
+    e3 = basevec(Vec{3}, 3)
+    ident_tensor = one(Tensor{2,3}) - otimes(e3, e3)
 
     # Remove all sigma_xz, sigma_yz and sigma_zz elements
     g = (i,j,k,l) -> case(k, l) ? 0.0 : ident_func(i,j,k,l)

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,9 +12,9 @@ type IsotropicHooke<:Elastic
     nu :: AbstractFloat
 end
 
-type VonMises<:Plastic
-    yield_stress :: AbstractFloat
-    yield_function :: Function
+type VonMises{F, T <: AbstractFloat}
+    yield_stress :: F
+    yield_function :: T
 end
 
 type Material{P<:AbstractMaterial}

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,29 +4,37 @@
 abstract type AbstractMaterial end
 
 abstract type Elastic<:AbstractMaterial end
+abstract type Plastic<:AbstractMaterial end
+abstract type HyperElastic<:AbstractMaterial end
 
 type IsotropicHooke<:Elastic
     youngs_modulus :: AbstractFloat
     nu :: AbstractFloat
 end
 
-abstract type Plastic<:AbstractMaterial end
-
-abstract type HyperElastic<:AbstractMaterial end
+type VonMises<:Plastic
+    yield_stress :: AbstractFloat
+    yield_function :: Function
+end
 
 type Material{P<:AbstractMaterial}
     dimension :: Int
     formulation :: Symbol
     finite_strain :: Bool
-    time_steps :: Vector{AbstractFloat}
+    time :: Vector{AbstractFloat}
     properties :: Dict{AbstractString, P}
+    trial_values :: Dict{AbstractString, Any}
+    history_values :: Dict{AbstractString, Array{Any}}
 end
 
 Material(dim; formulation=:test, finite_strain=false) = Material(dim,
                                                                  formulation,
                                                                  finite_strain,
-                                                                 Vector{AbstractFloat}(),
-                                                                 Dict{AbstractString, AbstractMaterial}())
+                                                                 Vector{AbstractFloat}(0),
+                                                                 Dict{AbstractString, AbstractMaterial}(),
+                                                                 Dict{AbstractString, Any}(),
+                                                                 Dict{AbstractString, Array{Any}}()
+                                                                 )
 
 function add_property!(material::Material, mat_property, name, params...)
     material.properties[name] = mat_property(params...)

--- a/test/test_elastic_material.jl
+++ b/test/test_elastic_material.jl
@@ -3,57 +3,85 @@
 
 using Tensors
 
+# See Hooke's law definitions from: https://en.wikipedia.org/wiki/Hooke's_law
+
 @testset "calculate response in 2D, plane stress" begin
+    # Material definitions
     E = 200e3
     nu = 0.3
-    D = E/(1.0 - nu^2) .* [
-                1.0  nu 0.0
-                nu  1.0 0.0
-                0.0 0.0 (1.0-nu)/2.0]
+    G = E / (2*(1 + nu))
+
+    # nabla u = dx/dX
     gradu = [0.125 0.125;
-             0.0   0.0]
+             0.45   0.01]
+    
+    # Small strains
     strain = 1/2*(gradu + gradu')
     strain_vec = [strain[1,1]; strain[2,2]; strain[1,2]]
-    stress_vec = D * ([1.0, 1.0, 2.0] .* strain_vec)
-    expected_stress_tensor = Tensor{1, 3}(stress_vec)
+
+    # Analytical stresses
+    sigma_x = E / (1-nu^2) * (strain_vec[1] + nu * strain_vec[2])
+    sigma_y = E / (1 - nu^2) * (strain_vec[2] + nu * strain_vec[1])
+    sigma_xy = G * 2 * strain_vec[3]
+    expected = [ sigma_x sigma_xy 0;
+                sigma_xy  sigma_y 0;
+                       0        0 0]
+
+    expected_stress_tensor = Tensor{2, 3}(expected)
+
+    # Calculation
     mat = Material(2, formulation=:plane_stress)
     elastic = IsotropicHooke(200e3, 0.3)
     add_property!(mat, elastic, "elastic")
 
     stress_tensor = calc_response(mat, gradu)
-    @test expected_stress_tensor == stress_tensor
-end  
-
+    @test isapprox(expected_stress_tensor, stress_tensor)
+end
 
 @testset "calculate response in 2D, plane strain" begin
+    # Material definitions
     E = 200e3
     nu = 0.3
-    D = E/((1.0+nu)*(1.0-2.0*nu)) .* [
-            1.0-nu      nu               0.0
-                nu  1.0-nu               0.0
-                0.0     0.0  (1.0-2.0*nu)/2.0]
+
+    # nabla u = dx/dX
     gradu = [0.125 0.125;
              0.0   0.0]
+
+    # Small strains
     strain = 1/2*(gradu + gradu')
     strain_vec = [strain[1,1]; strain[2,2]; strain[1,2]]
-    stress_vec = D * ([1.0, 1.0, 2.0] .* strain_vec)
-    expected_stress_tensor = Tensor{1, 3}(stress_vec)
+    G = E / (2*(1 + nu))
 
+    # Analytical stresses
+    sigma_x = 2*G / (1 - 2*nu) * ((1-nu) * strain_vec[1] + nu*strain_vec[2])
+    sigma_y = 2*G / (1 - 2*nu) * ((1-nu) * strain_vec[2] + nu*strain_vec[1])
+    sigma_z = 2*nu*G / (1 - 2*nu) * (strain_vec[1] + nu*strain_vec[2])
+    sigma_xy = G *(strain_vec[1] + strain_vec[2])
+    expected = [ sigma_x sigma_xy       0;
+                sigma_xy  sigma_y       0;
+                       0        0 sigma_z]
+    expected_stress_tensor = Tensor{2, 3}(expected)
+
+    # Calculation
     mat = Material(2, formulation=:plane_strain)
     elastic = IsotropicHooke(200e3, 0.3)
     add_property!(mat, elastic, "elastic")
 
     stress_tensor = calc_response(mat, gradu)
-    @test expected_stress_tensor == stress_tensor
-end 
+    @test isapprox(expected_stress_tensor, stress_tensor)
+end
 
 @testset "calculate response in 3D" begin
-    # Expected value
+    # Material definitions
     E = 200e3
     nu = 0.3
+
+    # nabla u = dx/dX
     gradu = [0.025 0.025 0.0;
              0.0   0.0   0.24;
              0.0   0.24   0.0]
+
+    # Elastic moduli
     D = E/((1.0+nu)*(1.0-2.0*nu)) * [
             1.0-nu nu nu 0.0 0.0 0.0
             nu 1.0-nu nu 0.0 0.0 0.0
@@ -62,6 +90,7 @@ end
             0.0 0.0 0.0 0.0 0.5-nu 0.0
             0.0 0.0 0.0 0.0 0.0 0.5-nu]
 
+    # Small strains
     strain = 1/2*(gradu' + gradu)
     strain_vec = [strain[1,1]; strain[2,2]; strain[3,3]; strain[1,2]; strain[2,3]; strain[1,3]]
     stress_vec = D * ([1.0, 1.0, 1.0, 2.0, 2.0, 2.0].*strain_vec)
@@ -70,10 +99,11 @@ end
                                             stress_vec[4] stress_vec[2] stress_vec[5];
                                             stress_vec[6] stress_vec[5] stress_vec[3]])
 
+    # Calculation
     mat = Material(3)
     elastic = IsotropicHooke(E, nu)
     add_property!(mat, elastic, "elastic")
-    
+
     stress_tensor = calc_response(mat, gradu)
     @test expected_stress_tensor == stress_tensor
 end


### PR DESCRIPTION
Changing arrays to matrices and vice versa can be troublesome,
and with this approach all calculations can be defined only
as tensors. Might not be a good idea, but at least try how
far this can be used.