### PR TITLE
Modifications to mecamatso

### DIFF
--- a/src/Materials.jl
+++ b/src/Materials.jl
@@ -110,7 +110,7 @@ export Chaboche
 
 # Material simulator to solve global system and run standard one element tests
 include("mecamatso.jl")
-export get_material_analysis
+export get_one_element_material_analysis, AxialStrainLoading, ShearStrainLoading, update_bc_elements!
 
 include("viscoplastic.jl")
 export ViscoPlastic

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ using FEMBase, Materials, Test
     @testset "test ideal plastic material model" begin
         include("test_idealplastic.jl")
     end
+    @testset "test ideal plastic material model with shear strain" begin
+        include("test_idealplastic_shear.jl")
+    end
     @testset "test chaboche material model" begin
         include("test_chaboche.jl")
     end

--- a/test/test_idealplastic_shear.jl
+++ b/test/test_idealplastic_shear.jl
@@ -1,0 +1,39 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/Materials.jl/blob/master/LICENSE
+
+using Materials, FEMBase, Test
+
+analysis, problem, element, bc_elements, ip = get_one_element_material_analysis(:IdealPlastic)
+update!(element, "youngs modulus", 200.0e3)
+update!(element, "poissons ratio", 0.3)
+update!(element, "yield stress", 100.0)
+
+times = [0.0]
+loads = [0.0]
+dt = 0.5
+E = 200.0e3
+nu = 0.3
+G = 0.5*E/(1+nu)
+syield = 100.0
+# vm = sqrt(3)*G*ga | ea = ga
+ea = 2*syield/(sqrt(3)*G)
+# Go to elastic border
+push!(times, times[end]+dt)
+push!(loads, loads[end] + ea*dt)
+ # Proceed to plastic flow
+push!(times, times[end]+dt)
+push!(loads, loads[end] + ea*dt)
+ # Reverse direction
+push!(times, times[end]+dt)
+push!(loads, loads[end] - ea*dt)
+ # Continue and pass yield criterion
+push!(times, times[end]+dt)
+push!(loads, loads[end] - 2*ea*dt)
+loading = ShearStrainLoading(times, loads)
+update_bc_elements!(bc_elements, loading)
+
+analysis.properties.t1 = maximum(times)
+run!(analysis)
+s31 = [ip("stress", t)[6] for t in times]
+s31_expected = [0.0, syield/sqrt(3.0), syield/sqrt(3.0), 0.0, -syield/sqrt(3.0)]
+@test isapprox(s31, s31_expected; rtol=1.0e-2)

--- a/test/test_mecamatso.jl
+++ b/test/test_mecamatso.jl
@@ -3,17 +3,18 @@
 
 using Materials, FEMBase, Test
 
-analysis, problem, element, bc_elements, ip = get_material_analysis(:IdealPlastic)
+analysis, problem, element, bc_elements, ip = get_one_element_material_analysis(:IdealPlastic)
 update!(element, "youngs modulus", 200.0e3)
 update!(element, "poissons ratio", 0.3)
 update!(element, "yield stress", 100.0)
-for element in bc_elements
-    update!(element, "fixed displacement 3", 0.0 => 0.0)
-    update!(element, "fixed displacement 3", 1.0 => 1.0e-3)
-    update!(element, "fixed displacement 3", 2.0 => -1.0e-3)
-    update!(element, "fixed displacement 3", 3.0 => 1.0e-3)
-end
+
+times = [0.0, 1.0, 2.0, 3.0]
+loads = [0.0, 1.0e-3, -1.0e-3, 1.0e-3]
+loading = AxialStrainLoading(times, loads)
+update_bc_elements!(bc_elements, loading)
+analysis.properties.t1 = maximum(times)
+
 run!(analysis)
-s33 = [ip("stress", t)[3] for t in 0.0:0.1:1.0]
-s33_expected = [0.0, 20.0, 40.0, 60.0, 80.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0]
+s33 = [ip("stress", t)[3] for t in times]
+s33_expected = [0.0, 100.0, -100.0, 100.0]
 @test isapprox(s33, s33_expected; rtol=1.0e-2)


### PR DESCRIPTION
* Added `AbstractLoading` types and corresponding `update_bc_elements!`
  functionality for standard `AxialStrainLoading` and `ShearStrainLoading`.
* Added pure shear test for perfect plastic material
* Modified `test_mecamatso.jl` to better reflect the introduced loading
* Changed mecamatso function `get_material_analysis` name to `get_one_element_material_analysis`