### PR TITLE
Fix basic_material_model_script.jl

### DIFF
--- a/examples/basic_material_model_script.jl
+++ b/examples/basic_material_model_script.jl
@@ -3,7 +3,7 @@ using Einsum
 using Test
 using NLsolve
 using Plots
-plotly()
+pyplot() # OLD BACKEND: plotly()
 
 # Tensors
 I_ = Matrix(1.0I,3,3) # Second order identity tensor


### PR DESCRIPTION
Plotting backend "Plotly" produced no plot, so changed the backend to "PyPlot", which then produces a plot.